### PR TITLE
Support ActiveJob usage & retries

### DIFF
--- a/lib/sidekiq/global_id/client_middleware.rb
+++ b/lib/sidekiq/global_id/client_middleware.rb
@@ -10,7 +10,10 @@ module Sidekiq
       # @param _redis_pool [ConnectionPool]
       # @return [Hash] sidekiq job
       def call(_worker_class, job, _queue, _redis_pool)
-        job['args'] = ActiveJob::Arguments.serialize(job['args'])
+        unless _worker_class.start_with?('ActiveJob::') ||
+               job['args'].any? {|arg| arg.is_a?(Hash) && arg.has_key?("_aj_globalid") }
+          job['args'] = ActiveJob::Arguments.serialize(job['args'])
+        end
         yield
       end
     end

--- a/lib/sidekiq/global_id/server_middleware.rb
+++ b/lib/sidekiq/global_id/server_middleware.rb
@@ -8,8 +8,13 @@ module Sidekiq
       # @param _queue [String]
       # @return [<any>] job args
       def call(_worker, job, _queue)
-        job['args'] = ActiveJob::Arguments.deserialize(job['args'])
+        _args = job['args']
+        unless _worker.class.name.start_with? 'ActiveJob::'
+          job['args'] = ActiveJob::Arguments.deserialize(_args)
+        end
         yield
+      ensure
+        job['args'] = _args
       end
     end
   end


### PR DESCRIPTION
Only serialize if not an active job and not already serialized.
Reset to serialized job arguments after execution so the job can be rescheduled if it failed.

The latter is necessary because the retry middleware uses dump_json to serialize the job on the retry queue.