### PR TITLE
Relax the version constraint on GlobalID

### DIFF
--- a/sidekiq-global_id.gemspec
+++ b/sidekiq-global_id.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'sidekiq', '>= 4.0'
-  spec.add_runtime_dependency 'globalid', '~> 0.3.7'
+  spec.add_runtime_dependency 'globalid', '>= 0.3.7', '< 0.5'
   spec.add_runtime_dependency 'activejob', '>= 4.2.5'
   spec.add_development_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
GlobalID is now in the 0.4 version range, which means you could have
a newer version than what is stated in the requirements for this gem.
Since 0.4 is backward-compatible with 0.3, let's relax the version
requirement to include it.